### PR TITLE
Refine emit option

### DIFF
--- a/examples/graphql/00runcode/main.py
+++ b/examples/graphql/00runcode/main.py
@@ -1,6 +1,6 @@
 import typing as t
 from metashape.declarative import mark
-from metashape.runtime import emit_with
+from metashape.runtime import get_walker
 from metashape.outputs.graphql import emit
 
 
@@ -13,4 +13,4 @@ class Todo:
 
 
 # main
-emit_with([Todo], emit=emit)
+emit(get_walker([Todo]))

--- a/examples/jsonschema/00runcode/main.py
+++ b/examples/jsonschema/00runcode/main.py
@@ -1,5 +1,5 @@
 from metashape.declarative import mark
-from metashape.runtime import emit_with
+from metashape.runtime import get_walker
 from metashape.outputs.jsonschema import emit
 
 
@@ -10,4 +10,4 @@ class Person:
 
 
 # main
-emit_with([Person], emit=emit)
+emit(get_walker([Person]))

--- a/examples/openapi/00runcode/main.py
+++ b/examples/openapi/00runcode/main.py
@@ -1,5 +1,5 @@
 from metashape.declarative import mark
-from metashape.runtime import emit_with
+from metashape.runtime import get_walker
 from metashape.outputs.openapi import emit
 
 
@@ -10,4 +10,4 @@ class Person:
 
 
 # main
-emit_with([Person], emit=emit)
+emit(get_walker([Person]))

--- a/examples/openapi/06ref/main.py
+++ b/examples/openapi/06ref/main.py
@@ -1,5 +1,5 @@
 from metashape.declarative import mark
-from metashape.runtime import emit_with
+from metashape.runtime import get_walker
 from metashape.outputs.openapi import emit
 
 
@@ -16,4 +16,4 @@ class Extra:
 
 
 # main
-emit_with([Person], emit=emit)
+emit(get_walker([Person]))

--- a/metashape/outputs/graphql/emit.py
+++ b/metashape/outputs/graphql/emit.py
@@ -92,8 +92,9 @@ class Scanner:
         result.name_to_type[typename] = schema
 
 
-def emit(walker: ModuleWalker, *, output: t.IO[str]) -> None:
+def emit(walker: ModuleWalker, *, output: t.Optional[t.IO[str]] = None) -> None:
     ctx = Context(walker)
+    output = output or walker.config.option.output
     scanner = Scanner(ctx)
 
     try:

--- a/metashape/outputs/jsonschema/emit.py
+++ b/metashape/outputs/jsonschema/emit.py
@@ -130,8 +130,9 @@ class Scanner:
         ] = schema
 
 
-def emit(walker: ModuleWalker, *, output: t.IO[str]) -> None:
+def emit(walker: ModuleWalker, *, output: t.Optional[t.IO[str]] = None) -> None:
     ctx = Context(walker)
+    output = output or walker.config.option.output
     scanner = Scanner(ctx)
 
     try:

--- a/metashape/outputs/openapi/emit.py
+++ b/metashape/outputs/openapi/emit.py
@@ -181,8 +181,9 @@ class Scanner:
         ] = schema
 
 
-def emit(walker: ModuleWalker, *, output: t.IO[str]) -> None:
+def emit(walker: ModuleWalker, *, output: t.Optional[t.IO[str]] = None) -> None:
     ctx = Context(walker)
+    output = output or walker.config.option.output
     scanner = Scanner(ctx)
 
     try:

--- a/metashape/outputs/raw/emit.py
+++ b/metashape/outputs/raw/emit.py
@@ -7,6 +7,7 @@ from metashape.analyze.walker import ModuleWalker
 logger = logging.getLogger(__name__)
 
 
-def emit(walker: ModuleWalker, *, output: t.IO[str]) -> None:
+def emit(walker: ModuleWalker, *, output: t.Optional[t.IO[str]] = None) -> None:
+    output = output or walker.config.option.output
     for m in walker.walk(ignore_private=walker.config.option.ignore_private):
         print(guess_mark(m), m, file=output)

--- a/metashape/runtime.py
+++ b/metashape/runtime.py
@@ -5,38 +5,14 @@ import logging
 import inspect
 import types
 from metashape.marker import mark, is_marked, guess_mark
-from metashape.types import Kind, Member, GuessMemberFunc, EmitFunc
+from metashape.types import Kind, Member, GuessMemberFunc
 from metashape.analyze.resolver import Resolver
 from metashape.analyze.walker import ModuleWalker
 from metashape.analyze.config import Config
 from metashape.analyze import typeinfo  # TODO: remove
-from metashape.outputs.raw.emit import emit as _emit_print_only
 
 
 logger = logging.getLogger(__name__)
-
-
-def emit_with(
-    target: t.Union[
-        None,
-        types.ModuleType,
-        t.Type[t.Any],
-        t.List[t.Type[t.Any]],
-        t.Dict[str, t.Type[t.Any]],
-    ] = None,
-    *,
-    emit: EmitFunc = _emit_print_only,
-    config: t.Optional[Config] = None,
-    aggressive: bool = False,
-    only: t.Optional[t.List[str]] = None,
-    _depth: int = 2,  # xxx: for black magic
-) -> None:
-    config = config or Config()
-    w = get_walker(
-        target, config=config, aggressive=aggressive, only=only, _depth=_depth
-    )
-    logger.debug("collect members: %d", len(w))
-    emit(w, output=config.option.output)
 
 
 def get_walker(

--- a/metashape/types.py
+++ b/metashape/types.py
@@ -7,16 +7,14 @@ T = t.TypeVar("T")
 Kind = tx.Literal["object", "enum", "ignore"]
 MetaData = t.Optional[t.Dict[str, t.Any]]
 
-# TODO: more strict definition
+# TODO: more strict typing
 Member = t.Type[t.Any]
 IsMemberFunc = t.Callable[[t.Type[t.Any]], bool]
 GuessMemberFunc = t.Callable[[t.Type[t.Any]], t.Optional[Kind]]
+EmitFunc = t.Callable[..., None]
 
 
 class _ForwardRef(tx.Protocol):
     @property
     def __forward_arg__(self) -> str:
         ...
-
-
-EmitFunc = t.Callable[..., None]


### PR DESCRIPTION
- default, using context.option.output (= sys.stdout)
- omit runtime:emit_with()