### PR TITLE
Annotated support

### DIFF
--- a/examples/openapi/18with-annotated/output.json
+++ b/examples/openapi/18with-annotated/output.json
@@ -1,0 +1,19 @@
+{
+  "components": {
+    "schemas": {
+      "Person": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "name of person"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/examples/openapi/18with-annotated/value.py
+++ b/examples/openapi/18with-annotated/value.py
@@ -1,0 +1,10 @@
+from typing_extensions import Annotated
+
+
+class Description:
+    def __init__(self, description: str) -> None:
+        self.description = description
+
+
+class Person:
+    name: Annotated[str, Description("name of person")]

--- a/examples/openapi/Makefile
+++ b/examples/openapi/Makefile
@@ -1,6 +1,6 @@
 OUTFILE := output.json
 
-default: 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16
+default: 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18
 
 typing:
 	mypy --strict .
@@ -51,4 +51,6 @@ typing:
 16:
 	python -m metashape.outputs.openapi --aggressive $@*/*.py | tee `echo $@*`/${OUTFILE}
 17:
+	python -m metashape.outputs.openapi --aggressive $@*/*.py | tee `echo $@*`/${OUTFILE}
+18:
 	python -m metashape.outputs.openapi --aggressive $@*/*.py | tee `echo $@*`/${OUTFILE}

--- a/metashape/_access.py
+++ b/metashape/_access.py
@@ -43,9 +43,9 @@ def _extract_metadata(
     typ: t.Type[t.Any],
     *,
     metadata: t.Optional[t.Dict[str, t.Any]] = None,
-    target_types: t.Collection = (t.Union, tx.Annotated),
+    target_types: t.List[object] = [t.Union, tx.Annotated],
     see_args: bool = False,
-) -> t.Dict[str, t.Any]:
+) -> t.Tuple[t.Type[t.Any], t.Dict[str, t.Any]]:
     if metadata is None:
         metadata = {}
 
@@ -73,8 +73,9 @@ def _extract_metadata(
 
 
 def iterate_props(
-    typ: t.Type[t.Any], *, ignore_private: bool = True, see_annotated: bool = True,
+    typ: t.Type[t.Any], *, ignore_private: bool = True,
 ) -> t.Iterable[t.Tuple[str, t.Type[t.Any], t.Optional[MetaData]]]:
+    see_annotated: bool = True
     for fieldname, fieldtype in t.get_type_hints(typ).items():
         if ignore_private and fieldname.startswith("_"):
             continue
@@ -82,7 +83,7 @@ def iterate_props(
 
         # typing_extensions.Annotated?
         if see_annotated:
-            fieldtype, metadata = _extract_metadata(fieldtype, metadata=metadata)
+            fieldtype, metadata = _extract_metadata(fieldtype, metadata=metadata)  # type: ignore
 
         yield fieldname, fieldtype, metadata
 

--- a/metashape/_access.py
+++ b/metashape/_access.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
 import typing as t
+import typing_extensions as tx
 import inspect
 from types import ModuleType
 from metashape.name import resolve_maybe as resolve_name_maybe
 from .types import MetaData, Member, _ForwardRef
 from .types import IteratePropsFunc
+
+
+class SeeArgsForMetadata:
+    see_args: bool = True
 
 
 def get_name(member: t.Union[ModuleType, Member, _ForwardRef]) -> str:
@@ -33,13 +39,52 @@ def get_metadata(cls: t.Type[t.Any], name: str) -> t.Optional[MetaData]:
     return getattr(prop, "metadata", None)  # type: ignore
 
 
+def _extract_metadata(
+    typ: t.Type[t.Any],
+    *,
+    metadata: t.Optional[t.Dict[str, t.Any]] = None,
+    target_types: t.Collection = (t.Union, tx.Annotated),
+    see_args: bool = False,
+) -> t.Dict[str, t.Any]:
+    if metadata is None:
+        metadata = {}
+
+    # for tx.Annotated
+    if hasattr(typ, "__metadata__"):
+        for x in typ.__metadata__:
+            if getattr(x, "see_args", False):
+                see_args = True
+            if hasattr(x, "as_metadata"):
+                metadata.update(x.as_metadata())
+            else:
+                metadata.update(x.__dict__)
+        typ = t.get_args(typ)[0]
+
+    if hasattr(typ, "__origin__") and typ.__origin__:
+        if metadata is None:
+            metadata = {}
+        if see_args or typ.__origin__ in target_types:
+            new_args = []
+            for x in t.get_args(typ):
+                new_arg, _ = _extract_metadata(x, metadata=metadata, see_args=see_args)
+                new_args.append(new_arg)
+            typ.__args__ = new_args
+    return typ, metadata
+
+
 def iterate_props(
-    typ: t.Type[t.Any], *, ignore_private: bool = True
+    typ: t.Type[t.Any], *, ignore_private: bool = True, see_annotated: bool = True,
 ) -> t.Iterable[t.Tuple[str, t.Type[t.Any], t.Optional[MetaData]]]:
     for fieldname, fieldtype in t.get_type_hints(typ).items():
         if ignore_private and fieldname.startswith("_"):
             continue
-        yield fieldname, fieldtype, get_metadata(typ, fieldname)
+        metadata = get_metadata(typ, fieldname)
+
+        # typing_extensions.Annotated?
+        if see_annotated:
+            fieldtype, metadata = _extract_metadata(fieldtype, metadata=metadata)
+
+        yield fieldname, fieldtype, metadata
 
 
 # type assertion

--- a/metashape/_access.py
+++ b/metashape/_access.py
@@ -4,6 +4,7 @@ import typing_extensions as tx
 import inspect
 from types import ModuleType
 from metashape.name import resolve_maybe as resolve_name_maybe
+from metashape.langhelpers import typing_get_args
 from .types import MetaData, Member, _ForwardRef
 from .types import IteratePropsFunc
 
@@ -58,14 +59,14 @@ def _extract_metadata(
                 metadata.update(x.as_metadata())
             else:
                 metadata.update(x.__dict__)
-        typ = t.get_args(typ)[0]
+        typ = typing_get_args(typ)[0]
 
     if hasattr(typ, "__origin__") and typ.__origin__:
         if metadata is None:
             metadata = {}
         if see_args or typ.__origin__ in target_types:
             new_args = []
-            for x in t.get_args(typ):
+            for x in typing_get_args(typ):
                 new_arg, _ = _extract_metadata(x, metadata=metadata, see_args=see_args)
                 new_args.append(new_arg)
             typ.__args__ = new_args

--- a/metashape/langhelpers.py
+++ b/metashape/langhelpers.py
@@ -3,10 +3,18 @@ import sys
 from .types import T
 
 
+# makedict
 if sys.version_info[:2] >= (3, 6):
     make_dict = dict
 else:
     from collections import OrderedDict as make_dict  # noqa
+
+# get_args
+typing_get_args = getattr(t, "get_args", None)
+if typing_get_args is None:
+    import typing_inspect as ti
+
+    typing_get_args = ti.get_args
 
 
 # stolen from pyramid

--- a/metashape/outputs/jsonschema/detect.py
+++ b/metashape/outputs/jsonschema/detect.py
@@ -1,9 +1,8 @@
 import typing as t
 import typing_extensions as tx
 import logging
-import typing_inspect
 from metashape import typeinfo
-
+from metashape.langhelpers import typing_get_args
 
 logger = logging.getLogger(__name__)
 JSONSchemaType = tx.Literal["boolean", "string", "integer", "number", "object", "array"]
@@ -38,4 +37,4 @@ def enum(info: typeinfo.TypeInfo) -> t.Tuple[str]:
     origin = getattr(typ, "__origin__", None)
     if origin != tx.Literal:
         return ()  # type: ignore
-    return typing_inspect.get_args(typ)  # type: ignore
+    return typing_get_args(typ)  # type: ignore

--- a/metashape/outputs/openapi/detect.py
+++ b/metashape/outputs/openapi/detect.py
@@ -1,9 +1,8 @@
 import typing as t
 import typing_extensions as tx
 import logging
-import typing_inspect
 from metashape import typeinfo
-
+from metashape.langhelpers import typing_get_args
 
 logger = logging.getLogger(__name__)
 JSONSchemaType = tx.Literal["boolean", "string", "integer", "number", "object", "array"]
@@ -38,4 +37,4 @@ def enum(info: typeinfo.TypeInfo) -> t.Tuple[str]:
     origin = getattr(typ, "__origin__", None)
     if origin != tx.Literal:
         return ()  # type:ignore
-    return typing_inspect.get_args(typ)  # type:ignore
+    return typing_get_args(typ)  # type:ignore

--- a/metashape/outputs/openapi/emit.py
+++ b/metashape/outputs/openapi/emit.py
@@ -161,6 +161,10 @@ class Scanner:
                 if enum:
                     prop["enum"] = enum
 
+            # description
+            if metadata.get("description"):
+                prop["description"] = metadata["description"]
+
             # default
             if resolver.metadata.has_default(metadata):
                 prop["default"] = resolver.metadata.resolve_default(metadata)

--- a/metashape/tests/test_access.py
+++ b/metashape/tests/test_access.py
@@ -5,6 +5,11 @@ import pytest
 from metashape._access import SeeArgsForMetadata
 
 
+# TODO: this is flake8's bug, string value is treated as type
+# metashape/tests/test_access.py:59:39: F722 syntax error in forward annotation 'nickname of object'
+# metashape/tests/test_access.py:64:52: F821 undefined name 'parents'
+
+
 class Description:
     def __init__(self, description: str) -> None:
         self.description = description
@@ -41,35 +46,45 @@ class WithPrivate:
 
 
 class WithAnnotated:
-    name: tx.Annotated[str, Description("name of object")]
+    name: tx.Annotated[str, Description("name of object")]  # noqa: F722
 
 
 class WithAnnotatedAsMetadata:
-    name: tx.Annotated[str, Description2("name of object")]
+    name: tx.Annotated[str, Description2("name of object")]  # noqa: F722
 
 
 class WithAnnotatedOptional:
-    nickname: tx.Annotated[t.Optional[str], Description("nickname of object")]
+    nickname: tx.Annotated[
+        t.Optional[str], Description("nickname of object")  # noqa: F722
+    ]
 
 
 class WithAnnotatedOptional2:
-    nickname: t.Optional[tx.Annotated[str, Description("nickname of object")]]
+    nickname: t.Optional[
+        tx.Annotated[str, Description("nickname of object")]  # noqa: F722,F821
+    ]
 
 
 class WithAnnotatedList:
-    parents: tx.Annotated[t.List[str], Description("parents")]
-    parents2: t.List[tx.Annotated[str, Description("parents")]]  # not extract
+    parents: tx.Annotated[t.List[str], Description("parents")]  # noqa: F821
+    parents2: t.List[
+        tx.Annotated[str, Description("parents")]  # noqa: F821
+    ]  # not extract
     parents3: tx.Annotated[
-        t.List[tx.Annotated[str, Description("parents")]], SeeArgsForMetadata()
+        t.List[tx.Annotated[str, Description("parents")]],  # noqa: F821
+        SeeArgsForMetadata(),
     ]
 
 
 class WithAnnotatedComplexNested:
     complex_nested: t.Dict[
-        str, t.Dict[str, tx.Annotated[str, Description("complex_nested")]]
+        str, t.Dict[str, tx.Annotated[str, Description("complex_nested")]]  # noqa: F821
     ]
     complex_nested2: tx.Annotated[
-        t.Dict[str, t.Dict[str, tx.Annotated[str, Description("complex_nested")]]],
+        t.Dict[
+            str,
+            t.Dict[str, tx.Annotated[str, Description("complex_nested")]],  # noqa: F821
+        ],
         SeeArgsForMetadata(),
     ]
 

--- a/metashape/tests/test_access.py
+++ b/metashape/tests/test_access.py
@@ -1,38 +1,176 @@
 # type: ignore
 import typing as t
+import typing_extensions as tx
 import pytest
+from metashape._access import SeeArgsForMetadata
+
+
+class Description:
+    def __init__(self, description: str) -> None:
+        self.description = description
+
+    def __repr__(self) -> repr:
+        return f"Description({self.description})"
+
+
+class Description2:
+    def __init__(self, message: repr) -> None:
+        self.message = message
+
+    def as_metadata(self) -> t.Dict[repr, t.Any]:
+        return {"description": self.message}
+
+    def __repr__(self) -> repr:
+        return f"Description({self.message})"
+
+
+class Person:
+    name: str
+    age: int
+
+
+class ActualPerson(Person):
+    age: t.Optional[int]
+    nickname: t.Optional[str]
+
+
+class WithPrivate:
+    name: str
+    _private_val: str
+    __dunder_val__: str
+
+
+class WithAnnotated:
+    name: tx.Annotated[str, Description("name of object")]
+
+
+class WithAnnotatedAsMetadata:
+    name: tx.Annotated[str, Description2("name of object")]
+
+
+class WithAnnotatedOptional:
+    nickname: tx.Annotated[t.Optional[str], Description("nickname of object")]
+
+
+class WithAnnotatedOptional2:
+    nickname: t.Optional[tx.Annotated[str, Description("nickname of object")]]
+
+
+class WithAnnotatedList:
+    parents: tx.Annotated[t.List[str], Description("parents")]
+    parents2: t.List[tx.Annotated[str, Description("parents")]]  # not extract
+    parents3: tx.Annotated[
+        t.List[tx.Annotated[str, Description("parents")]], SeeArgsForMetadata()
+    ]
+
+
+class WithAnnotatedComplexNested:
+    complex_nested: t.Dict[
+        str, t.Dict[str, tx.Annotated[str, Description("complex_nested")]]
+    ]
+    complex_nested2: tx.Annotated[
+        t.Dict[str, t.Dict[str, tx.Annotated[str, Description("complex_nested")]]],
+        SeeArgsForMetadata(),
+    ]
 
 
 @pytest.mark.parametrize(
-    "msg, clsname, want",
+    "msg, target_class, want",
     [
-        ("base", "Person", {"name": str, "age": int}),
+        (
+            "base",
+            Person,
+            {
+                "name": {"type": str, "metadata": {}},
+                "age": {"type": int, "metadata": {}},
+            },
+        ),
         (
             "inherited",
-            "ActualPerson",
-            {"name": str, "age": t.Optional[int], "nickname": t.Optional[str]},
+            ActualPerson,
+            {
+                "name": {"type": str, "metadata": {}},
+                "age": {"type": t.Optional[int], "metadata": {}},
+                "nickname": {"type": t.Optional[str], "metadata": {}},
+            },
         ),
-        ("ignore-private", "WithPrivate", {"name": str}),
+        ("ignore-private", WithPrivate, {"name": {"type": str, "metadata": {}}}),
+        (
+            "annotated",
+            WithAnnotated,
+            {"name": {"type": str, "metadata": {"description": "name of object"}}},
+        ),
+        (
+            "annotated-as-metadata",
+            WithAnnotatedAsMetadata,
+            {"name": {"type": str, "metadata": {"description": "name of object"}}},
+        ),
+        (
+            "annotated-with-optional",
+            WithAnnotatedOptional,
+            {
+                "nickname": {
+                    "type": t.Optional[str],
+                    "metadata": {"description": "nickname of object"},
+                },
+            },
+        ),
+        (
+            "annotated-with-optional2",
+            WithAnnotatedOptional2,
+            {
+                "nickname": {
+                    "type": t.Optional[str],
+                    "metadata": {"description": "nickname of object"},
+                },
+            },
+        ),
+        (
+            "annotated-with-see_args",
+            WithAnnotatedList,
+            {
+                "parents": {
+                    "type": t.List[str],
+                    "metadata": {"description": "parents"},
+                },
+                "parents2": {
+                    "type": t.List[tx.Annotated[str, Description("parents")]],
+                    "metadata": {},
+                },
+                "parents3": {
+                    "type": t.List[str],
+                    "metadata": {"description": "parents"},
+                },
+            },
+        ),
+        (
+            "annotated-with-see_args2",
+            WithAnnotatedComplexNested,
+            {
+                "complex_nested": {
+                    "type": t.Dict[
+                        str,
+                        t.Dict[str, tx.Annotated[str, Description("complex_nested")]],
+                    ],
+                    "metadata": {},
+                },
+                "complex_nested2": {
+                    "type": t.Dict[str, t.Dict[str, str]],
+                    "metadata": {"description": "complex_nested"},
+                },
+            },
+        ),
         # TODO: property?
     ],
 )
-def test_iterate_props(msg, clsname, want):
-    import typing as t
+def test_iterate_props(msg, target_class, want):
     from metashape._access import iterate_props as _callFUT
 
-    class Person:
-        name: str
-        age: int
+    got = {
+        name: {"type": typ, **({"metadata": metadata} if metadata is not None else {})}
+        for name, typ, metadata in _callFUT(target_class)
+    }
 
-    class ActualPerson(Person):
-        age: t.Optional[int]
-        nickname: t.Optional[str]
+    import json
 
-    class WithPrivate:
-        name: str
-        _private_val: str
-        __dunder_val__: str
-
-    target_class = locals()[clsname]  # xxx:
-    got = {name: typ for name, typ, _ in _callFUT(target_class)}
-    assert got == want
+    assert json.dumps(got, default=str) == json.dumps(want, default=str)

--- a/metashape/typeinfo.py
+++ b/metashape/typeinfo.py
@@ -4,7 +4,7 @@ from functools import partial
 from functools import lru_cache
 import dataclasses
 import typing_extensions as tx
-import typing_inspect
+from metashape.langhelpers import typing_get_args
 
 
 # TODO: support inheritance
@@ -111,7 +111,7 @@ def typeinfo(
     ),
 ) -> TypeInfo:
     raw = typ
-    args: t.List[t.Type[t.Any]] = typing_inspect.get_args(typ)
+    args: t.List[t.Type[t.Any]] = typing_get_args(typ)
     underlying = getattr(typ, "__origin__", None)
 
     if underlying is None:
@@ -176,10 +176,10 @@ def typeinfo(
         if hasattr(typ, "__origin__"):
             underlying = typ.__origin__
             if underlying == tx.Literal:
-                args = typing_inspect.get_args(typ)
+                args = typing_get_args(typ)
                 underlying = type(args[0])
             elif issubclass(underlying, t.Sequence):
-                args = typing_inspect.get_args(typ)
+                args = typing_get_args(typ)
                 return Container_with_children(
                     raw=raw,
                     type_=typ,
@@ -188,7 +188,7 @@ def typeinfo(
                     is_optional=is_optional,
                 )
             elif issubclass(underlying, t.Mapping):
-                args = typing_inspect.get_args(typ)
+                args = typing_get_args(typ)
                 return Container_with_children(
                     raw=raw,
                     type_=typ,
@@ -197,7 +197,7 @@ def typeinfo(
                     is_optional=is_optional,
                 )
             elif issubclass(underlying, t.Set):
-                args = typing_inspect.get_args(typ)
+                args = typing_get_args(typ)
                 return Container_with_children(
                     raw=raw,
                     type_=typ,
@@ -247,7 +247,7 @@ def omit_optional(
     if origin != t.Union:
         return typ, False
 
-    args = typing_inspect.get_args(typ)
+    args = typing_get_args(typ)
     if len(args) == 2:
         if args[0] == _nonetype:
             return args[1], True


### PR DESCRIPTION


```python
class Description:
    def __init__(self, description: str) -> None:
        self.description = description

    def __repr__(self) -> repr:
        return f"Description({self.description})"


class Description2:
    def __init__(self, message: repr) -> None:
        self.message = message

    def as_metadata(self) -> t.Dict[repr, t.Any]:
        return {"description": self.message}

    def __repr__(self) -> repr:
        return f"Description({self.message})"

class WithAnnotated:
    name: tx.Annotated[str, Description("name of object")]


class WithAnnotatedAsMetadata:
    name: tx.Annotated[str, Description2("name of object")]
```