### PR TITLE
Openapi input compatibility

### DIFF
--- a/examples/inputs/openapi/02nesting/shapes.py
+++ b/examples/inputs/openapi/02nesting/shapes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import typing
-from metadata.declarative import (
+from metashape.declarative import (
     field,
     ORIGINAL_NAME,
 )

--- a/examples/inputs/openapi/02nesting/shapes.py
+++ b/examples/inputs/openapi/02nesting/shapes.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 import typing
+from metadata.declarative import (
+    field,
+    ORIGINAL_NAME,
+)
 
 
 class Memo:
@@ -11,4 +15,4 @@ class Person:
     name: str
     age: typing.Optional[int]
     memo: Memo
-    optional_memo: typing.Optional[Memo]  # original is optional-memo
+    optional_memo: typing.Optional[Memo] = field(metadata={ORIGINAL_NAME: 'optional-memo'})

--- a/examples/inputs/openapi/06invalid-as-python-string/shapes.py
+++ b/examples/inputs/openapi/06invalid-as-python-string/shapes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import typing
-from metadata.declarative import (
+from metashape.declarative import (
     field,
     ORIGINAL_NAME,
 )

--- a/examples/inputs/openapi/06invalid-as-python-string/shapes.py
+++ b/examples/inputs/openapi/06invalid-as-python-string/shapes.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 import typing
+from metadata.declarative import (
+    field,
+    ORIGINAL_NAME,
+)
 
 
 # original is 💣
 class _invalid_:
-    _invalid_: typing.Optional[_invalid_]  # original is 💣
-    _invalid_G1: typing.Optional[str]  # original is ⽝
-    n100: typing.Optional[str]  # original is 100
-    n1234: typing.Optional[str]  # original is 1234
-    n1: typing.Optional[str]  # original is 1
-    _invalid__1: typing.Optional[str]  # original is -1
-    n8ball: typing.Optional[str]  # original is 8ball
+    _invalid_: typing.Optional[_invalid_] = field(metadata={ORIGINAL_NAME: '💣'})
+    _invalid_G1: typing.Optional[str] = field(metadata={ORIGINAL_NAME: '⽝'})
+    n100: typing.Optional[str] = field(metadata={ORIGINAL_NAME: '100'})
+    n1234: typing.Optional[str] = field(metadata={ORIGINAL_NAME: '1234'})
+    n1: typing.Optional[str] = field(metadata={ORIGINAL_NAME: '1'})
+    _invalid__1: typing.Optional[str] = field(metadata={ORIGINAL_NAME: '-1'})
+    n8ball: typing.Optional[str] = field(metadata={ORIGINAL_NAME: '8ball'})

--- a/examples/inputs/openapi/09nested-object/shapes.py
+++ b/examples/inputs/openapi/09nested-object/shapes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import typing
+from metadata.declarative import field
 
 
 # original is commit
@@ -38,14 +39,14 @@ class CommitCommitTree:
 
 # original is commitCommitCommitter
 class CommitCommitCommitter:
-    date: typing.Optional[str]
+    date: typing.Optional[str] = field(metadata={'openapi': {'description': 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'}})
     email: typing.Optional[str]
     name: typing.Optional[str]
 
 
 # original is commitCommitAuthor
 class CommitCommitAuthor:
-    date: typing.Optional[str]
+    date: typing.Optional[str] = field(metadata={'openapi': {'description': 'ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ'}})
     email: typing.Optional[str]
     name: typing.Optional[str]
 

--- a/examples/inputs/openapi/09nested-object/shapes.py
+++ b/examples/inputs/openapi/09nested-object/shapes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import typing
-from metadata.declarative import field
+from metashape.declarative import field
 
 
 # original is commit

--- a/examples/inputs/openapi/10enums/shapes.py
+++ b/examples/inputs/openapi/10enums/shapes.py
@@ -4,7 +4,7 @@ from metadata.declarative import field
 
 
 class Palette:
-    main: typing.Literal['black', 'white', 'red', 'green', 'blue'] = field(metadata={'openapi': {'enum': ['black', 'white', 'red', 'green', 'blue']}})
-    sort: typing.Optional[typing.Literal['asc', 'desc']] = field(metadata={'openapi': {'description': 'inline enums', 'enum': ['asc', 'desc']}})
-    sub1: typing.Optional[typing.Literal['black', 'white', 'red', 'green', 'blue']] = field(metadata={'openapi': {'description': 'Nullable enums', 'enum': ['black', 'white', 'red', 'green', 'blue', None], 'nullable': True}})
-    sub2: typing.Optional[typing.Literal['black', 'white', 'red', 'green', 'blue']] = field(metadata={'openapi': {'description': 'Nullable enums', 'enum': ['black', 'white', 'red', 'green', 'blue', None], 'nullable': True}})
+    main: typing.Literal['black', 'white', 'red', 'green', 'blue'] = field()
+    sort: typing.Optional[typing.Literal['asc', 'desc']] = field(metadata={'openapi': {'description': 'inline enums'}})
+    sub1: typing.Optional[typing.Literal['black', 'white', 'red', 'green', 'blue']] = field(metadata={'openapi': {'description': 'Nullable enums', 'nullable': True}})
+    sub2: typing.Optional[typing.Literal['black', 'white', 'red', 'green', 'blue']] = field(metadata={'openapi': {'description': 'Nullable enums', 'nullable': True}})

--- a/examples/inputs/openapi/10enums/shapes.py
+++ b/examples/inputs/openapi/10enums/shapes.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import typing
+from metadata.declarative import field
 
 
 class Palette:
-    main: typing.Literal['black', 'white', 'red', 'green', 'blue']
-    sort: typing.Optional[typing.Literal['asc', 'desc']]
-    sub1: typing.Optional[typing.Literal['black', 'white', 'red', 'green', 'blue']]
-    sub2: typing.Optional[typing.Literal['black', 'white', 'red', 'green', 'blue']]
+    main: typing.Literal['black', 'white', 'red', 'green', 'blue'] = field(metadata={'openapi': {'enum': ['black', 'white', 'red', 'green', 'blue']}})
+    sort: typing.Optional[typing.Literal['asc', 'desc']] = field(metadata={'openapi': {'description': 'inline enums', 'enum': ['asc', 'desc']}})
+    sub1: typing.Optional[typing.Literal['black', 'white', 'red', 'green', 'blue']] = field(metadata={'openapi': {'description': 'Nullable enums', 'enum': ['black', 'white', 'red', 'green', 'blue', None], 'nullable': True}})
+    sub2: typing.Optional[typing.Literal['black', 'white', 'red', 'green', 'blue']] = field(metadata={'openapi': {'description': 'Nullable enums', 'enum': ['black', 'white', 'red', 'green', 'blue', None], 'nullable': True}})

--- a/examples/inputs/openapi/10enums/shapes.py
+++ b/examples/inputs/openapi/10enums/shapes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import typing
-from metadata.declarative import field
+from metashape.declarative import field
 
 
 class Palette:

--- a/examples/inputs/openapi/11metadata/openapi.json
+++ b/examples/inputs/openapi/11metadata/openapi.json
@@ -38,6 +38,10 @@
         "minItems": 1,
         "maxItems": 3
       },
+      "date": {
+        "type": "string",
+        "pattern": "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]?\\d{2}:\\d{2})"
+      },
       "Toplevel": {
         "type": "object",
         "properties": {
@@ -51,6 +55,13 @@
             },
             "minItems": 1,
             "maxItems": 3
+          },
+          "date": {
+            "$ref": "#/components/schemas/date"
+          },
+          "inline-date": {
+            "type": "string",
+            "pattern": "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]?\\d{2}:\\d{2})"
           }
         }
       }

--- a/examples/inputs/openapi/11metadata/shapes.py
+++ b/examples/inputs/openapi/11metadata/shapes.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 import typing
+from metadata.declarative import (
+    field,
+    ORIGINAL_NAME,
+)
 
 
 # metadata: {'description': 'this is error model', 'type': 'object'}
@@ -22,5 +26,5 @@ class ErrorModel:
 class Toplevel:
     errors: typing.Optional[typing.List[ErrorModel]]
     # metadata: {'required': False, 'description': 'list of error model', 'type': 'array', 'minItems': 1, 'maxItems': 3}
-    errors_inline: typing.Optional[typing.List[ErrorModel]]  # original is errors-inline
+    errors_inline: typing.Optional[typing.List[ErrorModel]] = field(metadata={ORIGINAL_NAME: 'errors-inline'})
     # metadata: {'type': 'array', 'minItems': 1, 'maxItems': 3, 'required': False}

--- a/examples/inputs/openapi/11metadata/shapes.py
+++ b/examples/inputs/openapi/11metadata/shapes.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from metadata.declarative import (
+from metashape.declarative import (
     field,
     ORIGINAL_NAME,
 )

--- a/examples/inputs/openapi/11metadata/shapes.py
+++ b/examples/inputs/openapi/11metadata/shapes.py
@@ -13,22 +13,14 @@ class ErrorModel:
     """
 
     message: str
-    # metadata: {'type': 'string', 'required': True}
-    code: int = field(metadata={'openapi': {'minimum': 100, 'maximum': 600}})
-    # metadata: {'type': 'integer', 'minimum': 100, 'maximum': 600, 'required': True}
-    status: typing.Optional[str] = field(metadata={'openapi': {'readOnly': True}})
-    # metadata: {'type': 'string', 'readOnly': True, 'required': False}
-    statusCode: typing.Optional[int] = field(metadata={'openapi': {'minimum': 100, 'maximum': 600, 'deprecated': True}})
-    # metadata: {'type': 'integer', 'minimum': 100, 'maximum': 600, 'deprecated': True, 'required': False}
+    code: int = field(metadata={'openapi': {'type': 'integer', 'minimum': 100, 'maximum': 600, 'required': True}})
+    status: typing.Optional[str] = field(metadata={'openapi': {'type': 'string', 'readOnly': True, 'required': False}})
+    statusCode: typing.Optional[int] = field(metadata={'openapi': {'type': 'integer', 'minimum': 100, 'maximum': 600, 'deprecated': True, 'required': False}})
 
 
 # metadata: {'type': 'object'}
 class Toplevel:
-    errors: typing.Optional[typing.List[ErrorModel]] = field(metadata={'openapi': {'description': 'list of error model', 'minItems': 1, 'maxItems': 3}})
-    # metadata: {'required': False, 'description': 'list of error model', 'type': 'array', 'minItems': 1, 'maxItems': 3}
-    errors_inline: typing.Optional[typing.List[ErrorModel]] = field(metadata={ORIGINAL_NAME: 'errors-inline', 'openapi': {'minItems': 1, 'maxItems': 3}})
-    # metadata: {'type': 'array', 'minItems': 1, 'maxItems': 3, 'required': False}
-    date: typing.Optional[str] = field(metadata={'openapi': {'pattern': '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]?\\d{2}:\\d{2})'}})
-    # metadata: {'required': False, 'type': 'string', 'pattern': '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]?\\d{2}:\\d{2})'}
-    inline_date: typing.Optional[str] = field(metadata={ORIGINAL_NAME: 'inline-date', 'openapi': {'pattern': '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]?\\d{2}:\\d{2})'}})
-    # metadata: {'type': 'string', 'pattern': '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]?\\d{2}:\\d{2})', 'required': False}
+    errors: typing.Optional[typing.List[ErrorModel]] = field(metadata={'openapi': {'required': False, 'description': 'list of error model', 'type': 'array', 'minItems': 1, 'maxItems': 3}})
+    errors_inline: typing.Optional[typing.List[ErrorModel]] = field(metadata={ORIGINAL_NAME: 'errors-inline', 'openapi': {'type': 'array', 'minItems': 1, 'maxItems': 3, 'required': False}})
+    date: typing.Optional[str] = field(metadata={'openapi': {'required': False, 'type': 'string', 'pattern': '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]?\\d{2}:\\d{2})'}})
+    inline_date: typing.Optional[str] = field(metadata={ORIGINAL_NAME: 'inline-date', 'openapi': {'type': 'string', 'pattern': '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]?\\d{2}:\\d{2})', 'required': False}})

--- a/examples/inputs/openapi/11metadata/shapes.py
+++ b/examples/inputs/openapi/11metadata/shapes.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-import typing
 from metadata.declarative import (
     field,
     ORIGINAL_NAME,
 )
+import typing
 
 
 # metadata: {'description': 'this is error model', 'type': 'object'}
@@ -14,17 +14,21 @@ class ErrorModel:
 
     message: str
     # metadata: {'type': 'string', 'required': True}
-    code: int
+    code: int = field(metadata={'openapi': {'minimum': 100, 'maximum': 600}})
     # metadata: {'type': 'integer', 'minimum': 100, 'maximum': 600, 'required': True}
-    status: typing.Optional[str]
+    status: typing.Optional[str] = field(metadata={'openapi': {'readOnly': True}})
     # metadata: {'type': 'string', 'readOnly': True, 'required': False}
-    statusCode: typing.Optional[int]
+    statusCode: typing.Optional[int] = field(metadata={'openapi': {'minimum': 100, 'maximum': 600, 'deprecated': True}})
     # metadata: {'type': 'integer', 'minimum': 100, 'maximum': 600, 'deprecated': True, 'required': False}
 
 
 # metadata: {'type': 'object'}
 class Toplevel:
-    errors: typing.Optional[typing.List[ErrorModel]]
+    errors: typing.Optional[typing.List[ErrorModel]] = field(metadata={'openapi': {'description': 'list of error model', 'minItems': 1, 'maxItems': 3}})
     # metadata: {'required': False, 'description': 'list of error model', 'type': 'array', 'minItems': 1, 'maxItems': 3}
-    errors_inline: typing.Optional[typing.List[ErrorModel]] = field(metadata={ORIGINAL_NAME: 'errors-inline'})
+    errors_inline: typing.Optional[typing.List[ErrorModel]] = field(metadata={ORIGINAL_NAME: 'errors-inline', 'openapi': {'minItems': 1, 'maxItems': 3}})
     # metadata: {'type': 'array', 'minItems': 1, 'maxItems': 3, 'required': False}
+    date: typing.Optional[str] = field(metadata={'openapi': {'pattern': '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]?\\d{2}:\\d{2})'}})
+    # metadata: {'required': False, 'type': 'string', 'pattern': '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]?\\d{2}:\\d{2})'}
+    inline_date: typing.Optional[str] = field(metadata={ORIGINAL_NAME: 'inline-date', 'openapi': {'pattern': '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]?\\d{2}:\\d{2})'}})
+    # metadata: {'type': 'string', 'pattern': '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(Z|[+-]?\\d{2}:\\d{2})', 'required': False}

--- a/examples/inputs/openapi/12default/openapi.json
+++ b/examples/inputs/openapi/12default/openapi.json
@@ -6,7 +6,7 @@
         "properties": {
           "pi": {
             "type": "number",
-            "default": "3.14"
+            "default": 3.14
           }
         }
       },

--- a/examples/inputs/openapi/12default/openapi.json
+++ b/examples/inputs/openapi/12default/openapi.json
@@ -1,0 +1,39 @@
+{
+  "components": {
+    "schemas": {
+      "Value": {
+        "type": "object",
+        "properties": {
+          "pi": {
+            "type": "number",
+            "default": "3.14"
+          }
+        }
+      },
+      "Person": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": "foo"
+          },
+          "age": {
+            "type": "integer",
+            "default": 0
+          },
+          "gender": {
+            "type": "string",
+            "enum": ["male", "feamale", "unknown"],
+            "default": "unknown"
+          }
+        },
+        "required": [
+          "name",
+          "gender"
+        ],
+        "type": "object"
+      }
+    }
+  },
+  "openapi": "3.1.0"
+}
+

--- a/examples/inputs/openapi/12default/shapes.py
+++ b/examples/inputs/openapi/12default/shapes.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import typing
+from metadata.declarative import field
+
+
+class Value:
+    pi: typing.Optional[float] = field(default='3.14')
+
+
+class Person:
+    name: str = field(default='foo')
+    age: typing.Optional[int] = field(default=0)
+    gender: typing.Literal['male', 'feamale', 'unknown'] = field(default='unknown')

--- a/examples/inputs/openapi/12default/shapes.py
+++ b/examples/inputs/openapi/12default/shapes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import typing
-from metadata.declarative import field
+from metashape.declarative import field
 
 
 class Value:

--- a/examples/inputs/openapi/12default/shapes.py
+++ b/examples/inputs/openapi/12default/shapes.py
@@ -4,7 +4,7 @@ from metadata.declarative import field
 
 
 class Value:
-    pi: typing.Optional[float] = field(default='3.14')
+    pi: typing.Optional[float] = field(default=3.14)
 
 
 class Person:

--- a/examples/inputs/openapi/Makefile
+++ b/examples/inputs/openapi/Makefile
@@ -26,3 +26,6 @@ default: $(shell cat Makefile | grep -o '^[0-9][0-9]*:' | tr : "\n")
 	python -m metashape.inputs.openapi $(DIR)openapi.json | tee $(DIR)shapes.py
 11:
 	python -m metashape.inputs.openapi --verbose $(DIR)openapi.json | tee $(DIR)shapes.py
+
+lint:
+	flake8 --ignore E501 .

--- a/examples/inputs/openapi/Makefile
+++ b/examples/inputs/openapi/Makefile
@@ -26,6 +26,8 @@ default: $(shell cat Makefile | grep -o '^[0-9][0-9]*:' | tr : "\n")
 	python -m metashape.inputs.openapi $(DIR)openapi.json | tee $(DIR)shapes.py
 11:
 	python -m metashape.inputs.openapi --verbose $(DIR)openapi.json | tee $(DIR)shapes.py
+12:
+	python -m metashape.inputs.openapi $(DIR)openapi.json | tee $(DIR)shapes.py
 
 lint:
 	flake8 --ignore E501 .

--- a/metashape/inputs/openapi/__init__.py
+++ b/metashape/inputs/openapi/__init__.py
@@ -625,8 +625,11 @@ class Emitter:
                     if normalized_field_name == field_name:
                         m.stmt(f"{normalized_field_name}: {type_str}")
                     else:
+                        from_ = ctx.import_area.from_("metadata.declarative")
+                        field_sym = from_.import_("field")
+                        original_name_sym = from_.import_("ORIGINAL_NAME")
                         m.stmt(
-                            f"{normalized_field_name}: {type_str}  # original is {field_name}"
+                            f"{normalized_field_name}: {type_str} = {field_sym}(metadata={{{original_name_sym}: {field_name!r}}})"
                         )
                     if ctx.verbose:
                         m.stmt(

--- a/metashape/inputs/openapi/__init__.py
+++ b/metashape/inputs/openapi/__init__.py
@@ -628,7 +628,7 @@ class Emitter:
                     if len(metadata) < 3 and normalized_field_name == field_name:
                         m.stmt(f"{normalized_field_name}: {type_str}")
                     else:
-                        from_ = ctx.import_area.from_("metadata.declarative")
+                        from_ = ctx.import_area.from_("metashape.declarative")
                         field_sym = from_.import_("field")
                         metashape_metadata = {}
                         metashape_kwargs = {}

--- a/metashape/inputs/openapi/__init__.py
+++ b/metashape/inputs/openapi/__init__.py
@@ -630,8 +630,8 @@ class Emitter:
                     else:
                         from_ = ctx.import_area.from_("metashape.declarative")
                         field_sym = from_.import_("field")
-                        metashape_metadata = {}
-                        metashape_kwargs = {}
+                        metashape_metadata: t.Dict[t.Union[str, UnReprStr], t.Any] = {}
+                        metashape_kwargs: t.Dict[str, t.Any] = {}
 
                         # original name
                         if normalized_field_name != field_name:
@@ -649,7 +649,7 @@ class Emitter:
                         if ctx.verbose:
                             openapi_metadata = metadata
                         else:
-                            openapi_metadata = {
+                            openapi_metadata = {  # type: ignore
                                 k: v
                                 for k, v in metadata.items()
                                 if k not in ("required", "type", "enum", "default")

--- a/metashape/inputs/openapi/__init__.py
+++ b/metashape/inputs/openapi/__init__.py
@@ -646,11 +646,14 @@ class Emitter:
                             metashape_kwargs["default"] = repr(metadata["default"])
 
                         # symplify
-                        openapi_metadata = {
-                            k: v
-                            for k, v in metadata.items()
-                            if k not in ("required", "type", "enum", "default")
-                        }
+                        if ctx.verbose:
+                            openapi_metadata = metadata
+                        else:
+                            openapi_metadata = {
+                                k: v
+                                for k, v in metadata.items()
+                                if k not in ("required", "type", "enum", "default")
+                            }
                         if openapi_metadata:
                             metashape_metadata["openapi"] = openapi_metadata
 
@@ -658,12 +661,6 @@ class Emitter:
                             metashape_kwargs["metadata"] = metashape_metadata
                         m.stmt(
                             f"{normalized_field_name}: {type_str} = {field_sym}({LazyArgumentsAndKeywords(kwargs=metashape_kwargs)})"
-                        )
-
-                    if ctx.verbose:
-                        m.stmt(
-                            "# metadata: {metadata}",
-                            metadata=Repr(metadata).as_type_str(ctx),
                         )
 
         if str(ctx.import_area):

--- a/metashape/inputs/openapi/__init__.py
+++ b/metashape/inputs/openapi/__init__.py
@@ -8,6 +8,8 @@ import dictknife
 from functools import partial
 from collections import defaultdict, deque, Counter, namedtuple
 from prestring.python import Module
+from prestring.utils import LazyArgumentsAndKeywords
+from prestring.utils import UnRepr as UnReprStr
 from dictknife.langhelpers import make_dict
 from metashape.langhelpers import titleize, normalize
 
@@ -622,15 +624,33 @@ class Emitter:
                         field_type = Optional(field_type)
                     type_str = field_type.as_type_str(ctx)
                     normalized_field_name = normalize(field_name)
-                    if normalized_field_name == field_name:
+
+                    if len(metadata) < 3 and normalized_field_name == field_name:
                         m.stmt(f"{normalized_field_name}: {type_str}")
                     else:
                         from_ = ctx.import_area.from_("metadata.declarative")
                         field_sym = from_.import_("field")
-                        original_name_sym = from_.import_("ORIGINAL_NAME")
+                        metashape_metadata = {}
+
+                        if normalized_field_name != field_name:
+                            original_name_sym = from_.import_("ORIGINAL_NAME")
+                            metashape_metadata[
+                                UnReprStr(str(original_name_sym))
+                            ] = field_name
+
+                        # symplify
+                        openapi_metadata = {
+                            k: v
+                            for k, v in metadata.items()
+                            if k not in ("required", "type")
+                        }
+                        if openapi_metadata:
+                            metashape_metadata["openapi"] = openapi_metadata
+
                         m.stmt(
-                            f"{normalized_field_name}: {type_str} = {field_sym}(metadata={{{original_name_sym}: {field_name!r}}})"
+                            f"{normalized_field_name}: {type_str} = {field_sym}({LazyArgumentsAndKeywords(kwargs={'metadata': metashape_metadata})})"
                         )
+
                     if ctx.verbose:
                         m.stmt(
                             "# metadata: {metadata}",

--- a/metashape/inputs/openapi/__init__.py
+++ b/metashape/inputs/openapi/__init__.py
@@ -631,24 +631,33 @@ class Emitter:
                         from_ = ctx.import_area.from_("metadata.declarative")
                         field_sym = from_.import_("field")
                         metashape_metadata = {}
+                        metashape_kwargs = {}
 
+                        # original name
                         if normalized_field_name != field_name:
                             original_name_sym = from_.import_("ORIGINAL_NAME")
                             metashape_metadata[
                                 UnReprStr(str(original_name_sym))
                             ] = field_name
 
+                        # default
+                        if "default" in metadata:
+                            # todo: handle format
+                            metashape_kwargs["default"] = repr(metadata["default"])
+
                         # symplify
                         openapi_metadata = {
                             k: v
                             for k, v in metadata.items()
-                            if k not in ("required", "type")
+                            if k not in ("required", "type", "enum", "default")
                         }
                         if openapi_metadata:
                             metashape_metadata["openapi"] = openapi_metadata
 
+                        if metashape_metadata:
+                            metashape_kwargs["metadata"] = metashape_metadata
                         m.stmt(
-                            f"{normalized_field_name}: {type_str} = {field_sym}({LazyArgumentsAndKeywords(kwargs={'metadata': metashape_metadata})})"
+                            f"{normalized_field_name}: {type_str} = {field_sym}({LazyArgumentsAndKeywords(kwargs=metashape_kwargs)})"
                         )
 
                     if ctx.verbose:


### PR DESCRIPTION
ref #87 

- todo: use ORIGINAL_NAME
- todo: use field metadata's "openapi" field
- todo: support default